### PR TITLE
add optional watch, compile

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -2,10 +2,11 @@ path           = require 'path'
 RootsUtil      = require 'roots-util'
 webpack        = require 'webpack'
 {EventEmitter} = require 'events'
+_              = require 'lodash'
 
 module.exports = (opts) ->
   if opts.filename? then opts.filename = 'bundle.js'
-
+  
   webpack_initialized = false
   compiler = null
   emitter = new EventEmitter
@@ -18,11 +19,17 @@ module.exports = (opts) ->
         opts.context = @roots.root
         opts.output.path = path.join(@roots.config.output_path())
         compiler = webpack(opts)
-
-        compiler.watch opts.watchDelay or 200, (err, stats) ->
-          if err
-            throw new Error(err)
+        
+        callback = (err, stats) ->
+          if err then throw new Error(err)
           else if (statsJson = stats.toJson()).errors.length > 0
             throw new Error(error) for i, error of statsJson.errors
           else if statsJson.warnings.length > 0
             throw new Error(error) for i, error of statsJson.warnings
+        
+        # Temporary solution to define if user is watching `roots watch` or
+        # compiling `roots compile` the project. This solves a hang up from
+        # webpack if `roots compile` is used.
+        unless _.isUndefined @roots._events
+          compiler.watch(opts.watchDelay or 200, callback)
+        else compiler.run(callback)


### PR DESCRIPTION
When running roots compile - it hangs on and doesn't stop webpack.
This will add an optional option to the webpack config, which is removed before webpack consumes, and determines weather to run once or watch the directory
